### PR TITLE
Don't tempt undefined behaviour in incrementing null pointers

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -139,7 +139,10 @@ CBOR_API const char *cbor_error_string(CborError error);
 /* Encoder API */
 struct CborEncoder
 {
-    uint8_t *ptr;
+    union {
+        uint8_t *ptr;
+        ptrdiff_t bytes_needed;
+    };
     const uint8_t *end;
     int flags;
 };


### PR DESCRIPTION
When we wrote:
       encoder->end = encoder->ptr = NULL;
    }
    ++encoder->ptr;

We're incrementing a null pointer. This could be considered undefined
behaviour and the compiler would be free to remove the increment.

This commit solves that by using an integer called bytes_needed to store
the number of bytes needed.

The trick is, however, that this commit is actually a no-op: the new
member occupies the same storage as ptr and in all of the new
conditionals, both branches evaluate to the same code, so the
conditional can be removed.

The code is complex like this to ensure we don't run afoul of another
undefined behaviour: reading from a member of an union that was not the
last written to.

CID: 306167
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>