### PR TITLE
Implement checking of array and map sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ TINYCBOR_HEADERS = src/cbor.h src/cborjson.h
 TINYCBOR_SOURCES = \
 	src/cborerrorstrings.c \
 	src/cborencoder.c \
+	src/cborencoder_close_container_checked.c \
 	src/cborparser.c \
 	src/cborpretty.c \
 #

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -127,6 +127,10 @@ typedef enum CborError {
     CborErrorDuplicateObjectKeys,
     CborErrorInvalidUtf8TextString,
 
+    /* encoder errors */
+    CborErrorTooManyItems = 768,
+    CborErrorTooFewItems,
+
     /* internal implementation errors */
     CborErrorDataTooLarge = 1024,
     CborErrorNestingTooDeep,
@@ -144,6 +148,7 @@ struct CborEncoder
         ptrdiff_t bytes_needed;
     };
     const uint8_t *end;
+    size_t added;
     int flags;
 };
 typedef struct CborEncoder CborEncoder;
@@ -178,6 +183,7 @@ CBOR_INLINE_API CborError cbor_encode_double(CborEncoder *encoder, double value)
 CBOR_API CborError cbor_encoder_create_array(CborEncoder *encoder, CborEncoder *arrayEncoder, size_t length);
 CBOR_API CborError cbor_encoder_create_map(CborEncoder *encoder, CborEncoder *mapEncoder, size_t length);
 CBOR_API CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *containerEncoder);
+CBOR_API CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborEncoder *containerEncoder);
 
 /* Parser API */
 
@@ -185,7 +191,8 @@ enum CborParserIteratorFlags
 {
     CborIteratorFlag_IntegerValueTooLarge   = 0x01,
     CborIteratorFlag_NegativeInteger        = 0x02,
-    CborIteratorFlag_UnknownLength          = 0x04
+    CborIteratorFlag_UnknownLength          = 0x04,
+    CborIteratorFlag_ContainerIsMap         = 0x20
 };
 
 struct CborParser

--- a/src/cborencoder_close_container_checked.c
+++ b/src/cborencoder_close_container_checked.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#define _BSD_SOURCE 1
+#include "cbor.h"
+#include "cborconstants_p.h"
+#include "compilersupport_p.h"
+#include "extract_number_p.h"
+
+#include <assert.h>
+
+#include "assert_p.h"       /* Always include last */
+
+CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborEncoder *containerEncoder)
+{
+    const uint8_t *ptr = encoder->ptr;
+    CborError err = cbor_encoder_close_container(encoder, containerEncoder);
+    if (containerEncoder->flags & CborIteratorFlag_UnknownLength || encoder->end == NULL)
+        return err;
+
+    // check what the original length was
+    uint64_t actually_added;
+    err = extract_number(&ptr, encoder->ptr, &actually_added);
+    if (err)
+        return err;
+
+    if (containerEncoder->flags & CborIteratorFlag_ContainerIsMap) {
+        if (actually_added > SIZE_MAX / 2)
+            return CborErrorDataTooLarge;
+        actually_added *= 2;
+    }
+    return actually_added == containerEncoder->added ? CborNoError :
+           actually_added < containerEncoder->added ? CborErrorTooManyItems : CborErrorTooFewItems;
+}

--- a/src/cborerrorstrings.c
+++ b/src/cborerrorstrings.c
@@ -85,6 +85,12 @@ const char *cbor_error_string(CborError error)
     case CborErrorInvalidUtf8TextString:
         return _("invalid UTF-8 content in string");
 
+    case CborErrorTooManyItems:
+        return _("too many items added to encoder");
+
+    case CborErrorTooFewItems:
+        return _("too few items added to encoder");
+
     case CborErrorDataTooLarge:
         return _("internal error: data too large");
 

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -33,6 +33,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L || __cpp_static_assert >= 200410
+#  define cbor_static_assert(x)         static_assert(x, #x)
+#elif !defined(__cplusplus) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 406)
+#  define cbor_static_assert(x)         _Static_assert(x, #x)
+#else
+#  define cbor_static_assert(x)         ((void)sizeof(struct { int m : 2*!!(x) - 1; }))
+#endif
+
 #define STRINGIFY(x)            STRINGIFY2(x)
 #define STRINGIFY2(x)           #x
 

--- a/src/extract_number_p.h
+++ b/src/extract_number_p.h
@@ -1,0 +1,76 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#define _BSD_SOURCE 1
+#include "cbor.h"
+#include "cborconstants_p.h"
+#include "compilersupport_p.h"
+
+static inline uint16_t get16(const uint8_t *ptr)
+{
+    uint16_t result;
+    memcpy(&result, ptr, sizeof(result));
+    return cbor_ntohs(result);
+}
+
+static inline uint32_t get32(const uint8_t *ptr)
+{
+    uint32_t result;
+    memcpy(&result, ptr, sizeof(result));
+    return cbor_ntohl(result);
+}
+
+static inline uint64_t get64(const uint8_t *ptr)
+{
+    uint64_t result;
+    memcpy(&result, ptr, sizeof(result));
+    return cbor_ntohll(result);
+}
+
+static CborError extract_number(const uint8_t **ptr, const uint8_t *end, uint64_t *len)
+{
+    uint8_t additional_information = **ptr & SmallValueMask;
+    ++*ptr;
+    if (additional_information < Value8Bit) {
+        *len = additional_information;
+        return CborNoError;
+    }
+    if (unlikely(additional_information > Value64Bit))
+        return CborErrorIllegalNumber;
+
+    size_t bytesNeeded = 1 << (additional_information - Value8Bit);
+    if (unlikely(*ptr + bytesNeeded > end)) {
+        return CborErrorUnexpectedEOF;
+    } else if (bytesNeeded == 1) {
+        *len = (uint8_t)(*ptr)[0];
+    } else if (bytesNeeded == 2) {
+        *len = get16(*ptr);
+    } else if (bytesNeeded == 4) {
+        *len = get32(*ptr);
+    } else {
+        *len = get64(*ptr);
+    }
+    *ptr += bytesNeeded;
+    return CborNoError;
+}

--- a/src/src.pri
+++ b/src/src.pri
@@ -1,4 +1,10 @@
-SOURCES += $$PWD/cborparser.c $$PWD/cborencoder.c $$PWD/cborerrorstrings.c $$PWD/cborpretty.c
+SOURCES += \
+    $$PWD/cborencoder.c \
+    $$PWD/cborencoder_close_container_checked.c \
+    $$PWD/cborerrorstrings.c \
+    $$PWD/cborparser.c \
+    $$PWD/cborpretty.c \
+
 QMAKE_CFLAGS *= $$QMAKE_CFLAGS_SPLIT_SECTIONS
 QMAKE_LFLAGS *= $$QMAKE_LFLAGS_GCSECTIONS
 INCLUDEPATH += $$PWD


### PR DESCRIPTION
This fixes issue #4. The code is placed in a new file and function so
that only people who need it will pay the cost of this function. The
impact to existing code is minimal.

Before:
   text    data     bss     dec     hex filename
    945       0       0     945     3b1 cborencoder.o
   2743       0       0    2743     ab7 cborparser.o
After:
   1060       0       0    1060     424 cborencoder.o
   2756       0       0    2756     ac4 cborparser.o

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>