### PR TITLE
Build fix when using a C compiler

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -33,7 +33,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L || __cpp_static_assert >= 200410
+#if __STDC_VERSION__ >= 201112L || (defined(__cplusplus) && __cplusplus >= 201103L) || (defined(__cpp_static_assert) && __cpp_static_assert >= 200410)
 #  define cbor_static_assert(x)         static_assert(x, #x)
 #elif !defined(__cplusplus) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 406)
 #  define cbor_static_assert(x)         _Static_assert(x, #x)


### PR DESCRIPTION
Check if __cplusplus is defined before checking its value.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>