### PR TITLE
Fix a parsing issue caused by pointer wraparounds

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -108,7 +108,7 @@ static CborError preparse_value(CborValue *it)
     }
 
     size_t bytesNeeded = descriptor < Value8Bit ? 0 : (1 << (descriptor - Value8Bit));
-    if (it->ptr + 1 + bytesNeeded > parser->end)
+    if (bytesNeeded + 1 > (size_t)(parser->end - it->ptr))
         return CborErrorUnexpectedEOF;
 
     uint8_t majortype = type >> MajorTypeShift;
@@ -521,7 +521,7 @@ static CborError iterate_string_chunks(const CborValue *value, char *buffer, siz
         err = extract_length(value->parser, &ptr, &total);
         if (err)
             return err;
-        if (ptr + total > value->parser->end)
+        if (total > (size_t)(value->parser->end - ptr))
             return CborErrorUnexpectedEOF;
         if (total <= *buflen)
             *result = func(buffer, ptr, total);
@@ -556,7 +556,7 @@ static CborError iterate_string_chunks(const CborValue *value, char *buffer, siz
             if (unlikely(add_check_overflow(total, chunkLen, &newTotal)))
                 return CborErrorDataTooLarge;
 
-            if (ptr + chunkLen > value->parser->end)
+            if (chunkLen > (size_t)(value->parser->end - ptr))
                 return CborErrorUnexpectedEOF;
 
             if (*result && *buflen >= newTotal)

--- a/src/extract_number_p.h
+++ b/src/extract_number_p.h
@@ -60,7 +60,7 @@ static CborError extract_number(const uint8_t **ptr, const uint8_t *end, uint64_
         return CborErrorIllegalNumber;
 
     size_t bytesNeeded = 1 << (additional_information - Value8Bit);
-    if (unlikely(*ptr + bytesNeeded > end)) {
+    if (unlikely(bytesNeeded > (size_t)(end - *ptr))) {
         return CborErrorUnexpectedEOF;
     } else if (bytesNeeded == 1) {
         *len = (uint8_t)(*ptr)[0];


### PR DESCRIPTION
If the size of the string was a suitable value, the "ptr + total" check
could overflow and we wouldn't know because the sum would most likely be
smaller than value->parser->end. We would then proceed to allocate a
silly amount of memory.

I never caught this in my own testing because, on Linux, the heap
usually starts in the low 4 GB of the address space, so adding
0xffffffff000000000 would not cause an overflow. However, on OS X, the
heap starts above 4 GB, so the pointer does wrap around.

So test specifically for the pointer wraparound cases, plus the case of
sizes larger than the address space in 32-bit systems.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>