### PR TITLE
Fix build msvc

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -1,0 +1,39 @@
+CFLAGS = -W3
+
+TINYCBOR_HEADERS = src\cbor.h src\cborjson.h
+TINYCBOR_SOURCES = \
+	src\cborerrorstrings.c \
+	src\cborencoder.c \
+	src\cborencoder_close_container_checked.c \
+	src\cborparser.c \
+	src\cborpretty.c
+TINYCBOR_OBJS = \
+	src\cborerrorstrings.obj \
+	src\cborencoder.obj \
+	src\cborencoder_close_container_checked.obj \
+	src\cborparser.obj \
+	src\cborpretty.obj
+
+all: lib\tinycbor.lib
+check: tests\Makefile lib\tinycbor.lib
+	cd tests & $(MAKE) check
+silentcheck:
+	cd tests & set TESTARGS=-silent & $(MAKE) -s check
+tests\Makefile: tests\tests.pro
+	qmake -o $@ $**
+
+lib\tinycbor.lib: $(TINYCBOR_OBJS)
+	-if not exist lib\NUL md lib
+	lib -nologo /out:$@ $**
+
+mostlyclean:
+	-del $(TINYCBOR_OBJS)
+clean: mostlyclean
+	-del lib\tinycbor.lib
+	if exist tests\Makefile (cd tests & $(MAKE) clean)
+distclean: clean
+	if exist tests\Makefile (cd tests & $(MAKE) distclean)
+
+{src\}.c{src\}.obj:
+	$(CC) -nologo $(CFLAGS) -Isrc -DTINYCBOR_VERSION="" -c -Fo$@ $<
+

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -57,9 +57,19 @@ extern "C" {
 #endif
 #ifndef CBOR_INLINE_API
 #  if defined(__cplusplus)
+#    define CBOR_INLINE inline
 #    define CBOR_INLINE_API inline
 #  else
-#    define CBOR_INLINE_API static inline
+#    define CBOR_INLINE_API static CBOR_INLINE
+#    if defined(_MSC_VER)
+#      define CBOR_INLINE __inline
+#    elif defined(__GNUC__)
+#      define CBOR_INLINE __inline__
+#    elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#      define CBOR_INLINE inline
+#    else
+#      define CBOR_INLINE
+#    endif
 #  endif
 #endif
 

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -60,6 +60,7 @@ static CborError value_to_json(FILE *out, CborValue *it, int flags, CborType typ
 static CborError dump_bytestring_base16(char **result, CborValue *it)
 {
     static const char characters[] = "0123456789abcdef";
+    size_t i;
     size_t n = 0;
     uint8_t *buffer;
     CborError err = cbor_value_calculate_string_length(it, &n);
@@ -75,7 +76,7 @@ static CborError dump_bytestring_base16(char **result, CborValue *it)
     err = cbor_value_copy_byte_string(it, buffer + n - 1, &n, it);
     assert(err == CborNoError);
 
-    for (size_t i = 0; i < n; ++i) {
+    for (i = 0; i < n; ++i) {
         uint8_t byte = buffer[n + i];
         buffer[2*i]     = characters[byte >> 4];
         buffer[2*i + 1] = characters[byte & 0xf];

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -25,6 +25,8 @@
 #ifndef COMPILERSUPPORT_H
 #define COMPILERSUPPORT_H
 
+#include "cbor.h"
+
 #ifndef _BSD_SOURCE
 #  define _BSD_SOURCE
 #endif
@@ -49,6 +51,12 @@
 #  define cbor_static_assert(x)         _Static_assert(x, #x)
 #else
 #  define cbor_static_assert(x)         ((void)sizeof(char[2*!!(x) - 1]))
+#endif
+#if __STDC_VERSION__ >= 199901L || defined(__cplusplus)
+/* inline is a keyword */
+#else
+/* use the definition from cbor.h */
+#  define inline    CBOR_INLINE
 #endif
 
 #define STRINGIFY(x)            STRINGIFY2(x)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+Makefile
+debug
+release
+target_wrapper.*

--- a/tests/encoder/encoder.pro
+++ b/tests/encoder/encoder.pro
@@ -4,5 +4,6 @@ CONFIG += testcase parallel_test c++11
 QT = core testlib
 
 INCLUDEPATH += ../../src
-POST_TARGETDEPS += ../../lib/libtinycbor.a
+msvc: POST_TARGETDEPS = ../../lib/tinycbor.lib
+else: POST_TARGETDEPS += ../../lib/libtinycbor.a
 LIBS += $$POST_TARGETDEPS

--- a/tests/encoder/tst_encoder.cpp
+++ b/tests/encoder/tst_encoder.cpp
@@ -275,10 +275,19 @@ void addFixedData()
     QTest::newRow("-16777215.f") << raw("\xfa\xcb\x7f\xff\xff") << QVariant(-16777215.f);
     QTest::newRow("-16777215.") << raw("\xfb\xc1\x6f\xff\xff\xe0\0\0\0") << QVariant::fromValue(-16777215.);
 
+#ifdef Q_CC_MSVC
+    // MSVC NaNs have the sign bit unset
+    QTest::newRow("qnan_f") << raw("\xfa\x7f\xc0\0\0") << QVariant::fromValue<float>(qQNaN());
+    QTest::newRow("qnan") << raw("\xfb\x7f\xf8\0\0\0\0\0\0") << QVariant(qQNaN());
+    QTest::newRow("snan_f") << raw("\xfa\x7f\xc0\0\0") << QVariant::fromValue<float>(qSNaN());
+    QTest::newRow("snan") << raw("\xfb\x7f\xf0\0\0\0\0\0\1") << QVariant(qSNaN());
+#else
+    // GCC NaNs have the sign bit set
     QTest::newRow("qnan_f") << raw("\xfa\xff\xc0\0\0") << QVariant::fromValue<float>(qQNaN());
     QTest::newRow("qnan") << raw("\xfb\xff\xf8\0\0\0\0\0\0") << QVariant(qQNaN());
     QTest::newRow("snan_f") << raw("\xfa\x7f\xc0\0\0") << QVariant::fromValue<float>(qSNaN());
     QTest::newRow("snan") << raw("\xfb\x7f\xf8\0\0\0\0\0\0") << QVariant(qSNaN());
+#endif
     QTest::newRow("-inf_f") << raw("\xfa\xff\x80\0\0") << QVariant::fromValue<float>(-qInf());
     QTest::newRow("-inf") << raw("\xfb\xff\xf0\0\0\0\0\0\0") << QVariant(-qInf());
     QTest::newRow("+inf_f") << raw("\xfa\x7f\x80\0\0") << QVariant::fromValue<float>(qInf());

--- a/tests/parser/parser.pro
+++ b/tests/parser/parser.pro
@@ -5,5 +5,6 @@ QT = core testlib
 DEFINES += CBOR_PARSER_MAX_RECURSIONS=16
 
 INCLUDEPATH += ../../src
-POST_TARGETDEPS += ../../lib/libtinycbor.a
+msvc: POST_TARGETDEPS = ../../lib/tinycbor.lib
+else: POST_TARGETDEPS += ../../lib/libtinycbor.a
 LIBS += $$POST_TARGETDEPS

--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -263,7 +263,13 @@ void addFixedData()
     QTest::newRow("2.f^64") << raw("\xfa\x5f\x80\0\0") << "1.8446744073709552e+19f";
     QTest::newRow("2.^64") << raw("\xfb\x43\xf0\0\0\0\0\0\0") << "1.8446744073709552e+19";
 
-    QTest::newRow("nan_f16") << raw("\xf9\x7e\x00") << "nan";
+    QTest::newRow("nan_f16") << raw("\xf9\x7e\x00")
+#ifdef Q_CC_MSVC
+                             << "-nan(ind)"
+#else
+                             << "nan"
+#endif
+                                ;
     QTest::newRow("nan_f") << raw("\xfa\x7f\xc0\0\0") << "nan";
     QTest::newRow("nan") << raw("\xfb\x7f\xf8\0\0\0\0\0\0") << "nan";
     QTest::newRow("-inf_f16") << raw("\xf9\xfc\x00") << "-inf";

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,2 +1,3 @@
 TEMPLATE = subdirs
 SUBDIRS = parser encoder cpp tojson
+msvc: SUBDIRS -= tojson

--- a/tests/tojson/tojson.pro
+++ b/tests/tojson/tojson.pro
@@ -3,5 +3,6 @@ QT = core testlib
 
 SOURCES += tst_tojson.cpp
 INCLUDEPATH += ../../src
-POST_TARGETDEPS += ../../lib/libtinycbor.a
+msvc: POST_TARGETDEPS = ../../lib/tinycbor.lib
+else: POST_TARGETDEPS += ../../lib/libtinycbor.a
 LIBS += $$POST_TARGETDEPS


### PR DESCRIPTION
This series of commits fixes the build and makes the parser and encoder tests pass with MSVC.

The to and from JSON functionality is not enabled with MSVC.

@dantler, @dthaler