### PR TITLE
Fix compilation for systems without math.h header

### DIFF
--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -25,6 +25,7 @@
 #define _BSD_SOURCE 1
 #include "cbor.h"
 #include "compilersupport_p.h"
+#include "math_support_p.h"
 
 #include <float.h>
 #include <inttypes.h>

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -28,6 +28,7 @@
 #include "cbor.h"
 #include "cborjson.h"
 #include "compilersupport_p.h"
+#include "math_support_p.h"
 
 #include <float.h>
 #include <inttypes.h>

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -32,7 +32,6 @@
 #endif
 #include <assert.h>
 #include <float.h>
-#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -208,22 +207,6 @@ static inline unsigned short encode_half(double val)
         return 0;
     }
     return sign | ((exp + 15) << 10) | mant;
-#endif
-}
-
-// this function was copied & adapted from RFC 7049 Appendix D
-static inline double decode_half(unsigned short half)
-{
-#ifdef __F16C__
-    return _cvtsh_ss(half);
-#else
-    int exp = (half >> 10) & 0x1f;
-    int mant = half & 0x3ff;
-    double val;
-    if (exp == 0) val = ldexp(mant, -24);
-    else if (exp != 31) val = ldexp(mant + 1024, exp - 25);
-    else val = mant == 0 ? INFINITY : NAN;
-    return half & 0x8000 ? -val : val;
 #endif
 }
 

--- a/src/math_support_p.h
+++ b/src/math_support_p.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#ifndef MATH_SUPPORT_H
+#define MATH_SUPPORT_H
+
+#include <math.h>
+
+// this function was copied & adapted from RFC 7049 Appendix D
+static inline double decode_half(unsigned short half)
+{
+#ifdef __F16C__
+    return _cvtsh_ss(half);
+#else
+    int exp = (half >> 10) & 0x1f;
+    int mant = half & 0x3ff;
+    double val;
+    if (exp == 0) val = ldexp(mant, -24);
+    else if (exp != 31) val = ldexp(mant + 1024, exp - 25);
+    else val = mant == 0 ? INFINITY : NAN;
+    return half & 0x8000 ? -val : val;
+#endif
+}
+
+#endif // MATH_SUPPORT_H
+


### PR DESCRIPTION
cbortojson and cborpretty depends on decode_half function from
compilersupport_p.h that uses math.h functions. As cbortojson and
cborpretty are usually important only in development phase, move math
dependency to another header so it is now possible to compile tinycbor
in systems that doesn't provide math.h header

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>