### PR TITLE
Add missing dependencies to cbordump build

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -6,7 +6,7 @@ all: ../bin ../bin/cbordump
 ../bin:
 	@-mkdir ../bin
 
-../bin/cbordump: cbordump.o cborparser.o cborerrorstrings.o cborpretty.o
+../bin/cbordump: cbordump.o cborparser.o cborparser_dup_string.o cbortojson.o cborerrorstrings.o cborpretty.o
 	$(CC) -o $@ $^
 	$(RM) $^
 


### PR DESCRIPTION
Compilation was failing when trying to compile cbordump running make in
tools directory. Add missing dependencies, cbortojson and
cborparser_dup_string to cbordump Makefile.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>