### PR TITLE
Fix compilation error due to file descriptor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ silentcheck: | lib/libtinycbor.a
 	TESTARGS=-silent $(MAKE) -f $(MAKEFILE) -s check
 configure: .config
 .config: Makefile.configure
-	$(MAKE) -f $(SRCDIR)Makefile.configure OUT='>&10' configure 10> $@
+	$(MAKE) -f $(SRCDIR)Makefile.configure OUT='>&9' configure 9> $@
 
 lib bin:
 	$(MKDIR) $@


### PR DESCRIPTION
In Makefile, the file descriptor 10 is used to redirect input to .config:
$(MAKE) -f $(SRCDIR)Makefile.configure OUT='>&10' configure 10> $@

This patch replaces this file descriptor from to 10 to 9 as "Redirections using file descriptors greater than 9 should be used with care, as they may conflict with file descriptors the shell uses internally." (cf. https://www.gnu.org/software/bash/manual/html_node/Redirections.html)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>