### PR TITLE
Give a name to unnamed union in CborEncoder

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -162,7 +162,7 @@ struct CborEncoder
     union {
         uint8_t *ptr;
         ptrdiff_t bytes_needed;
-    };
+    } data;
     const uint8_t *end;
     size_t added;
     int flags;
@@ -204,12 +204,12 @@ CBOR_API CborError cbor_encoder_close_container_checked(CborEncoder *encoder, co
 
 CBOR_INLINE_API size_t cbor_encoder_get_buffer_size(const CborEncoder *encoder, const uint8_t *buffer)
 {
-    return (size_t)(encoder->ptr - buffer);
+    return (size_t)(encoder->data.ptr - buffer);
 }
 
 CBOR_INLINE_API size_t cbor_encoder_get_extra_bytes_needed(const CborEncoder *encoder)
 {
-    return encoder->end ? 0 : (size_t)encoder->bytes_needed;
+    return encoder->end ? 0 : (size_t)encoder->data.bytes_needed;
 }
 
 /* Parser API */

--- a/src/cborencoder_close_container_checked.c
+++ b/src/cborencoder_close_container_checked.c
@@ -55,14 +55,14 @@
  */
 CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborEncoder *containerEncoder)
 {
-    const uint8_t *ptr = encoder->ptr;
+    const uint8_t *ptr = encoder->data.ptr;
     CborError err = cbor_encoder_close_container(encoder, containerEncoder);
     if (containerEncoder->flags & CborIteratorFlag_UnknownLength || encoder->end == NULL)
         return err;
 
     /* check what the original length was */
     uint64_t actually_added;
-    err = extract_number(&ptr, encoder->ptr, &actually_added);
+    err = extract_number(&ptr, encoder->data.ptr, &actually_added);
     if (err)
         return err;
 


### PR DESCRIPTION
cbor.h contains an unnamed union in CborEncoder structure, this functionality is
not always supported by all compilers, especially it seems that the Blackfin
build on buildroot fails (with gcc 4.3). This patch names this union "data".

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>