### PR TITLE
Properly manage open_memstream availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ TINYCBOR_SOURCES = \
 	src/cborparser_dup_string.c \
 	src/cborpretty.c \
 	src/cbortojson.c \
-	$(if $(open_memstream-pass),,src/open_memstream.c) \
 #
 CBORDUMP_SOURCES = tools/cbordump/cbordump.c
 
@@ -71,6 +70,17 @@ ifeq ($(origin QMAKE),file)
 endif
 
 -include .config
+
+# if open_memstream is unavailable on the system, try to implement our own
+# version using funopen or fopencookie
+ifeq ($(open_memstream-pass),)
+  ifeq ($(funopen-pass)$(fopencookie-pass),)
+    CFLAGS += -DWITHOUT_OPEN_MEMSTREAM
+    $(warning warning: funopen and fopencookie unavailable, open_memstream can not be implemented and conversion to JSON will not work properly!)
+  else
+    TINYCBOR_SOURCES += src/open_memstream.c
+  endif
+endif
 
 # json2cbor depends on an external library (cJSON)
 ifneq ($(cjson-pass)$(system-cjson-pass),)

--- a/Makefile.configure
+++ b/Makefile.configure
@@ -1,10 +1,11 @@
-ALLTESTS = open_memstream funopen gc_sections \
+ALLTESTS = open_memstream funopen fopencookie gc_sections \
 	   system-cjson cjson
 MAKEFILE := $(lastword $(MAKEFILE_LIST))
 OUT :=
 
 PROGRAM-open_memstream = extern int open_memstream(); int main() { return open_memstream(); }
 PROGRAM-funopen = extern int funopen(); int main() { return funopen(); }
+PROGRAM-fopencookie = extern int fopencookie(); int main() { return fopencookie(); }
 PROGRAM-gc_sections = int main() {}
 CCFLAGS-gc_sections = -Wl,--gc-sections
 

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -149,6 +149,7 @@ typedef enum CborError {
     /* errors in converting to JSON */
     CborErrorJsonObjectKeyIsAggregate,
     CborErrorJsonObjectKeyNotString,
+    CborErrorJsonNotImplemented,
 
     CborErrorOutOfMemory = ~0U / 2 + 1,
     CborErrorInternalError = ~0U

--- a/src/cborerrorstrings.c
+++ b/src/cborerrorstrings.c
@@ -155,6 +155,8 @@ const char *cbor_error_string(CborError error)
     case CborErrorJsonObjectKeyNotString:
         return _("conversion to JSON failed: key in object is not a string");
 
+    case CborErrorJsonNotImplemented:
+        return _("conversion to JSON failed: open_memstream unavailable");
 
     case CborErrorInternalError:
         return _("internal error");

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -402,6 +402,11 @@ static CborError stringify_map_key(char **key, CborValue *it, int flags, CborTyp
 {
     (void)flags;    /* unused */
     (void)type;     /* unused */
+#ifdef WITHOUT_OPEN_MEMSTREAM
+    (void)key;      /* unused */
+    (void)it;       /* unused */
+    return CborErrorJsonNotImplemented;
+#else
     size_t size;
 
     FILE *memstream = open_memstream(key, &size);
@@ -412,6 +417,7 @@ static CborError stringify_map_key(char **key, CborValue *it, int flags, CborTyp
     if (unlikely(fclose(memstream) < 0 || *key == NULL))
         return CborErrorInternalError;
     return err;
+#endif
 }
 
 static CborError array_to_json(FILE *out, CborValue *it, int flags, ConversionStatus *status)


### PR DESCRIPTION
- Update Makefile.configure to test the availability of fopencookie
- If open_memstream is not available on the system AND funopen or fopencookie are available, compile our own version of open_memstream
- If open_memstream can not be compiled, return a new error (CborErrorJsonNotImplemented)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>