### PR TITLE
Fix detection of system-cjson

### DIFF
--- a/Makefile.configure
+++ b/Makefile.configure
@@ -14,7 +14,7 @@ PROGRAM-cjson += \#include <cJSON.h>\n
 PROGRAM-cjson += int main() { return cJSON_False; }
 CCFLAGS-cjson = -I$(dir $(MAKEFILE))src/cjson
 PROGRAM-system-cjson = $(PROGRAM-cjson)
-CCLFAGS-system-cjson = -lcJSON
+CCFLAGS-system-cjson = -lcJSON
 
 sink:
 	@echo >&2 Please run from the top-level Makefile.


### PR DESCRIPTION
Replace CCLFAGS-system-cjson by CCFLAGS-system-cjson

Fixes:
  - http://autobuild.buildroot.net/results/8fc/8fc7365e0dc777edc57e950a84df7fddc13c6776

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>