### PR TITLE
Stop-gap fixes for compiler warnings

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -290,7 +290,7 @@ static inline CborError encode_number_no_update(CborEncoder *encoder, uint64_t u
     if (ui < Value8Bit) {
         *bufstart += shiftedMajorType;
     } else {
-        unsigned more = 0;
+		uint8_t more = 0;
         if (ui > 0xffU)
             ++more;
         if (ui > 0xffffU)

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -155,7 +155,7 @@ static CborError extract_length(const CborParser *parser, const uint8_t **ptr, s
         return err;
     }
 
-    *len = v;
+    *len = (size_t)v;
     if (v != *len)
         return CborErrorDataTooLarge;
     return CborNoError;
@@ -799,13 +799,13 @@ CborError cbor_value_get_int_checked(const CborValue *value, int *result)
         if (unlikely(v > (unsigned) -(INT_MIN + 1)))
             return CborErrorDataTooLarge;
 
-        *result = v;
+        *result = (int)v;
         *result = -*result - 1;
     } else {
         if (unlikely(v > (uint64_t)INT_MAX))
             return CborErrorDataTooLarge;
 
-        *result = v;
+        *result = (int)v;
     }
     return CborNoError;
 

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -210,7 +210,15 @@ static inline unsigned short encode_half(double val)
         /* underflow, make zero */
         return 0;
     }
+
+//
+// bugbug: working with tinycbor folks to address this properly. 
+// Issue https://github.com/01org/tinycbor/issues/47
+//
+#pragma warning(disable:4244)
     return sign | ((exp + 15) << 10) | mant;
+#pragma warning(default:4244)
+
 #endif
 }
 


### PR DESCRIPTION
Related to #45. This is just to show the lines that I had to change to get a clean build on VS2015 compiler. 