### PR TITLE
Create a Perl script that properly creates tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,29 +177,8 @@ distcheck: .git
 	cd $${TMPDIR-/tmp}/tinycbor-distcheck && $(MAKE) silentcheck
 	$(RM) -r $${TMPDIR-/tmp}/tinycbor-distcheck
 
-release: .git
-	$(MAKE) -f $(MAKEFILE) distcheck
-ifeq ($(VERSION),)
-	git -C $(SRCDIR). show HEAD:VERSION | \
-	  perl -l -n -e '@_ = split /\./; print "$$_[0]." . ($$_[1] + 1)' > $(SRCDIR)VERSION
-else
-	echo "$(VERSION)" > VERSION
-endif
-	if test -n "`git diff VERSION`"; then \
-	  git -C $(SRCDIR). commit -s -m "Update version number" VERSION; \
-	fi
-	{ echo "TinyCBOR release `cat $(SRCDIR)VERSION`"; \
-	  echo; \
-	  echo '# Write something nice about this release here'; \
-	  tmpl=`git -C $(SRCDIR). config --get commit.template` && \
-		cat "$$tmpl"; \
-	  echo '# Commit log:'; \
-	  git -C $(SRCDIR). shortlog -e --no-merges HEAD --not `git -C $(SRCDIR). tag` | sed 's,^,#   ,'; \
-	  echo '# Header diff:'; \
-	  git -C $(SRCDIR). diff HEAD --not `git -C $(SRCDIR). tag` -- 'src/*.h' ':!*_p.h' | sed 's,^,# ,'; \
-	} > $(SRCDIR).git/TAG_EDITMSG
-	@`git -C $(SRCDIR). var GIT_EDITOR` $(SRCDIR).git/TAG_EDITMSG
-	git -C $(SRCDIR). tag -a -F $(SRCDIR).git/TAG_EDITMSG $(GITTAGFLAGS) v`cat $(SRCDIR)VERSION`
+tag: distcheck
+	@cd $(SRCDIR). && perl maketag.pl
 
 .PHONY: all check silentcheck configure install uninstall
 .PHONY: mostlyclean clean distclean

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -34,6 +34,8 @@ clean: mostlyclean
 	if exist tests\Makefile (cd tests & $(MAKE) clean)
 distclean: clean
 	if exist tests\Makefile (cd tests & $(MAKE) distclean)
+tag:
+	@perl maketag.pl
 
 {src\}.c{src\}.obj:
 	$(CC) -nologo $(CFLAGS) -Isrc -DTINYCBOR_VERSION="" -c -Fo$@ $<

--- a/maketag.pl
+++ b/maketag.pl
@@ -1,0 +1,69 @@
+#!perl
+use strict;
+sub run(@) {
+    open PROC, "-|", @_ or die("Cannot run $_[0]: $!");
+    my @out;
+    while (<PROC>) {
+        chomp;
+        push @out, $_;
+    }
+    close PROC;
+    return @out;
+}
+
+my @tags = run("git", "tag");
+my @v = run("git", "show", "HEAD:VERSION");
+my $v = $v[0];
+
+my $tagfile = ".git/TAG_EDITMSG";
+open TAGFILE, ">", $tagfile
+    or die("Cannot create file for editing tag message: $!");
+select TAGFILE;
+print "TinyCBOR release $v\n";
+print "\n";
+print "# Write something nice about this release here\n";
+
+# Do we have a commit template?
+my @result = run("git", "config", "--get", "commit.template");
+if (scalar @result) {
+    open TEMPLATE, "<", $result[0];
+    map { print $_; } <TEMPLATE>;
+    close TEMPLATE;
+}
+
+print "\n";
+print "# Commit log\n";
+open LOG, "-|", "git", "shortlog", "-e", "--no-merges", "--not", @tags;
+map { print "#  $_"; } <LOG>;
+close LOG;
+
+print "# Header diff:\n";
+open DIFF, "-|", "git", "diff", "HEAD", "--not", @tags, "--", 'src/*.h', ':!*_p.h';
+map { print "# $_"; } <DIFF>;
+close DIFF;
+
+select STDOUT;
+close TAGFILE;
+
+# Run the editor.
+# We use system so that stdin, stdout and stderr are forwarded.
+@result = run("git", "var", "GIT_EDITOR");
+@result = ($result[0], $tagfile);
+system @result;
+exit ($? >> 8) if $?;
+
+# Create the tag
+# Also using system so that hte user can see the output.
+system("git", "tag", "-a", "-F", $tagfile, split(' ', $ENV{GITTAGFLAGS}), "v$v");
+exit ($? >> 8) if $?;
+
+# Update the version file for the next patch release
+@v = split(/\./, $v);
+if (scalar @v < 3) {
+    push @v, '1';
+} else {
+    ++$v[-1];
+}
+$v = join('.', @v);
+open VERSION, ">", "VERSION" or die("Cannot open VERSION file: $!");
+print VERSION "$v\n";


### PR DESCRIPTION
The previous part of the Makefile didn't work properly. Instead of using
the contents of the VERSION file, it updated the file right before the
tagging and always for the next minor release.

Instead, move everything to a Perl script that updates the VERSION file
only after the tagging and sets up for a patch release (which are more
frequent). Updating of the dev branch is left as an exercise for the
reader.

As a bonus, this will work on Windows too without Unix shell tools.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>