### PR TITLE
Add a way to replace the call to malloc with a different allocator

### DIFF
--- a/src/cborparser_dup_string.c
+++ b/src/cborparser_dup_string.c
@@ -29,7 +29,15 @@
 #endif
 
 #include "cbor.h"
-#include <stdlib.h>
+#ifdef CBOR_ALLOC_INCLUDE
+#  include CBOR_ALLOC_INCLUDE
+#else
+#  include <stdlib.h>
+#endif
+
+#ifndef CBOR_ALLOC
+#  define CBOR_ALLOC        malloc
+#endif
 
 /**
  * \fn CborError cbor_value_dup_text_string(const CborValue *value, char **buffer, size_t *buflen, CborValue *next)
@@ -99,7 +107,7 @@ CborError _cbor_value_dup_string(const CborValue *value, void **buffer, size_t *
         return err;
 
     ++*buflen;
-    *buffer = malloc(*buflen);
+    *buffer = CBOR_ALLOC(*buflen);
     if (!*buffer) {
         /* out of memory */
         return CborErrorOutOfMemory;

--- a/tests/parser/alloc.h
+++ b/tests/parser/alloc.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C"
+#else
+extern
+#endif
+void *my_alloc(size_t size);

--- a/tests/parser/parser.pro
+++ b/tests/parser/parser.pro
@@ -1,8 +1,11 @@
-SOURCES += tst_parser.cpp ../../src/cborparser.c
+SOURCES += tst_parser.cpp ../../src/cborparser.c ../../src/cborparser_dup_string.c
+HEADERS += alloc.h
 
 CONFIG += testcase parallel_test c++11
 QT = core testlib
 DEFINES += CBOR_PARSER_MAX_RECURSIONS=16
+DEFINES += CBOR_ALLOC_INCLUDE=\\\"alloc.h\\\"
+DEFINES += CBOR_ALLOC=my_alloc
 
 INCLUDEPATH += ../../src
 msvc: POST_TARGETDEPS = ../../lib/tinycbor.lib

--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -25,6 +25,8 @@
 #define _XOPEN_SOURCE 700
 #include <QtTest>
 #include "cbor.h"
+#include "alloc.h"
+
 #include <locale.h>
 #include <stdio.h>
 
@@ -44,7 +46,7 @@ private slots:
     void fixed_data();
     void fixed();
     void strings_data();
-    void strings() { fixed(); }
+    void strings();
     void tags_data();
     void tags() { fixed(); }
     void tagTags_data() { tags_data(); }
@@ -88,6 +90,13 @@ private slots:
     void recursionLimit_data();
     void recursionLimit();
 };
+
+static size_t my_alloc_count = 0;
+void *my_alloc(size_t size)
+{
+    ++my_alloc_count;
+    return malloc(size);
+}
 
 CborError parseOne(CborValue *it, QString *parsed)
 {
@@ -377,6 +386,13 @@ void tst_Parser::strings_data()
 {
     addColumns();
     addStringsData();
+}
+
+void tst_Parser::strings()
+{
+    my_alloc_count = 0;
+    fixed();
+    QCOMPARE(my_alloc_count, size_t(1));
 }
 
 void addTagsData()


### PR DESCRIPTION
Just define the macro CBOR_ALLOC to your allocator when compiling the
source file cbor_parser_dup_string.c. The function will call that
allocator instead of malloc.

You probably also want to define CBOR_ALLOC_INCLUDE to the header file
that contains the declaration of that function.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>