### PR TITLE
Support C99 standards (enums, assert)

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -151,8 +151,8 @@ typedef enum CborError {
     CborErrorJsonObjectKeyNotString,
     CborErrorJsonNotImplemented,
 
-    CborErrorOutOfMemory = ~0U / 2 + 1,
-    CborErrorInternalError = ~0U
+    CborErrorOutOfMemory = (int) (~0U / 2 + 1),
+    CborErrorInternalError = (int) ~0U
 } CborError;
 
 CBOR_API const char *cbor_error_string(CborError error);

--- a/src/cborconstants_p.h
+++ b/src/cborconstants_p.h
@@ -44,7 +44,7 @@ enum {
     IndefiniteLength        = 31U,
 
     MajorTypeShift          = SmallValueBitLength,
-    MajorTypeMask           = ~0U << MajorTypeShift,
+    MajorTypeMask           = (int) (~0U << MajorTypeShift),
 
     BreakByte               = (unsigned)Break | (SimpleTypesType << MajorTypeShift)
 };

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -49,7 +49,7 @@
 
 #if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L || __cpp_static_assert >= 200410
 #  define cbor_static_assert(x)         static_assert(x, #x)
-#elif !defined(__cplusplus) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 406)
+#elif !defined(__cplusplus) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 406) && (__STDC_VERSION__ > 199901L)
 #  define cbor_static_assert(x)         _Static_assert(x, #x)
 #else
 #  define cbor_static_assert(x)         ((void)sizeof(char[2*!!(x) - 1]))


### PR DESCRIPTION
Cast enum values to int to prevent errors like:
   deps/tinycbor/src/cborconstants_p.h:47:31:\
   error: ISO C restricts enumerator values to range of ‘int’\
   [-Werror=pedantic]
   MajorTypeMask           = ~0U << MajorTypeShift,

"error: ISO C99 does not support" ‘Static_assert’

This effort is needed for RIOT port of iotivity-contrained

Change-Id: Ib8addf7c6703298faecfc4006cf2a9e3c1036d4c
Bug-RIOT: https://github.com/RIOT-OS/RIOT/issues/6241