### PR TITLE
Fix stack corruption due to calling convention mismatch

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -915,6 +915,12 @@ static uintptr_t iterate_memcmp(char *s1, const uint8_t *s2, size_t len)
     return memcmp(s1, (const char *)s2, len) == 0;
 }
 
+static uintptr_t iterate_memcpy(char *dest, const uint8_t *src, size_t len)
+{
+    memcpy(dest, src, len);
+    return true;
+}
+
 static CborError iterate_string_chunks(const CborValue *value, char *buffer, size_t *buflen,
                                        bool *result, CborValue *next, IterateFunction func)
 {
@@ -1059,7 +1065,7 @@ CborError _cbor_value_copy_string(const CborValue *value, void *buffer,
 {
     bool copied_all;
     CborError err = iterate_string_chunks(value, (char*)buffer, buflen, &copied_all, next,
-                                          buffer ? (IterateFunction)memcpy : iterate_noop);
+                                          buffer ? iterate_memcpy : iterate_noop);
     return err ? err :
                  copied_all ? CborNoError : CborErrorOutOfMemory;
 }

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -917,8 +917,7 @@ static uintptr_t iterate_memcmp(char *s1, const uint8_t *s2, size_t len)
 
 static uintptr_t iterate_memcpy(char *dest, const uint8_t *src, size_t len)
 {
-    memcpy(dest, src, len);
-    return true;
+    return (uintptr_t)memcpy(dest, src, len);
 }
 
 static CborError iterate_string_chunks(const CborValue *value, char *buffer, size_t *buflen,


### PR DESCRIPTION
Standard library implementations may specify calling convention for memcpy()
explicitly. However, the cbor* APIs don't do that. If you compile the lib
with default calling convention that doesn't match the calling convention of
memcpy(), the iterate_string_chunks() will not setup the stack for memcpy()
call correctly resulting in a stack corruption. The compiler doesn't catch
this issue because of the cast that is being applied when passing memcpy()
to the iterate_string_chunks().

The fix is to wrap mempy() in a function that conforms to the declaration of
the IterateFunction which does two things, removes the need for a cast and
uncouples memcpy() calling convention from the rest of the cbor* APIs.

Signed-off-by: Alex Radutskiy (alex.radutskiy@microsoft.com)