### PR TITLE
Don't cast an actual string literal to uint8_t*

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -977,8 +977,10 @@ static CborError iterate_string_chunks(const CborValue *value, char *buffer, siz
     }
 
     /* is there enough room for the ending NUL byte? */
-    if (*result && *buflen > total)
-        *result = !!func(buffer + total, (const uint8_t *)"", 1);
+    if (*result && *buflen > total) {
+        uint8_t nul[] = { 0 };
+        *result = !!func(buffer + total, nul, 1);
+    }
     *buflen = total;
 
     if (next) {


### PR DESCRIPTION
This removes an ugly cast from the source and an unnecessary 1-byte
variable from the .rodata section.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>