### PR TITLE
Fix static compilation of json2cbor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ bin/cbordump: $(CBORDUMP_SOURCES:.c=.o) lib/libtinycbor.a
 
 bin/json2cbor: $(JSON2CBOR_SOURCES:.c=.o) lib/libtinycbor.a
 	@$(MKDIR) -p bin
-	$(CC) -o $@ $(LDFLAGS) $(LDFLAGS_CJSON) $^ $(LDLIBS) -lm
+	$(CC) -o $@ $(LDFLAGS) $^ $(LDFLAGS_CJSON) $(LDLIBS) -lm
 
 tinycbor.pc: tinycbor.pc.in
 	$(SED) > $@ < $< \


### PR DESCRIPTION
json2cbor depends on cjson so tools/json2cbor/json2cbor.o must be
before -lcjson

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>