### PR TITLE
More detailed cbordump

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -487,10 +487,13 @@ enum CborPrettyFlags {
     CborPrettyNumericEncodingIndicators     = 0x01,
     CborPrettyTextualEncodingIndicators     = 0,
 
+    CborPrettyIndicateIndetermineLength     = 0x02,
+    CborPrettyIndicateOverlongNumbers       = 0x04,
+
     CborPrettyShowStringFragments           = 0x100,
     CborPrettyMergeStringFragments          = 0,
 
-    CborPrettyDefaultFlags          = 0
+    CborPrettyDefaultFlags          = CborPrettyIndicateIndetermineLength
 };
 
 CBOR_API CborError cbor_value_to_pretty_advance_flags(FILE *out, CborValue *value, int flags);

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -484,6 +484,9 @@ CBOR_INLINE_API CborError cbor_value_get_double(const CborValue *value, double *
 /* Human-readable (dump) API */
 
 enum CborPrettyFlags {
+    CborPrettyNumericEncodingIndicators     = 0x01,
+    CborPrettyTextualEncodingIndicators     = 0,
+
     CborPrettyDefaultFlags          = 0
 };
 

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -482,11 +482,17 @@ CBOR_INLINE_API CborError cbor_value_get_double(const CborValue *value, double *
 }
 
 /* Human-readable (dump) API */
+
+enum CborPrettyFlags {
+    CborPrettyDefaultFlags          = 0
+};
+
+CBOR_API CborError cbor_value_to_pretty_advance_flags(FILE *out, CborValue *value, int flags);
 CBOR_API CborError cbor_value_to_pretty_advance(FILE *out, CborValue *value);
 CBOR_INLINE_API CborError cbor_value_to_pretty(FILE *out, const CborValue *value)
 {
     CborValue copy = *value;
-    return cbor_value_to_pretty_advance(out, &copy);
+    return cbor_value_to_pretty_advance_flags(out, &copy, CborPrettyDefaultFlags);
 }
 
 #ifdef __cplusplus

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -487,6 +487,9 @@ enum CborPrettyFlags {
     CborPrettyNumericEncodingIndicators     = 0x01,
     CborPrettyTextualEncodingIndicators     = 0,
 
+    CborPrettyShowStringFragments           = 0x100,
+    CborPrettyMergeStringFragments          = 0,
+
     CborPrettyDefaultFlags          = 0
 };
 

--- a/src/cborinternal_p.h
+++ b/src/cborinternal_p.h
@@ -80,5 +80,6 @@ enum {
 };
 
 CBOR_INTERNAL_API CBOR_INTERNAL_API_CC CborError _cbor_value_extract_number(const uint8_t **ptr, const uint8_t *end, uint64_t *len);
+CBOR_INTERNAL_API CBOR_INTERNAL_API_CC CborError _cbor_value_prepare_string_iteration(CborValue *it);
 
 #endif /* CBORINTERNAL_P_H */


### PR DESCRIPTION
This branch extends the cbor_value_to_pretty API with a new enum and updates the documentation. As a consequence, we can now match the RFC 7049 recommendations, even if the default settings remain as they were in previous TinyCBOR versions.

```c
enum CborPrettyFlags {
    CborPrettyNumericEncodingIndicators     = 0x01,
    CborPrettyTextualEncodingIndicators     = 0,

    CborPrettyIndicateIndetermineLength     = 0x02,
    CborPrettyIndicateOverlongNumbers       = 0x04,

    CborPrettyShowStringFragments           = 0x100,
    CborPrettyMergeStringFragments          = 0,

    CborPrettyDefaultFlags          = CborPrettyIndicateIndetermineLength
};
```

