### PR TITLE
Omit -ffunction-sections #pragma on GCC 7 and later

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -171,7 +171,7 @@
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && \
-    (__GNUC__ * 100 + __GNUC_MINOR__ >= 404)
+    (__GNUC__ * 100 + __GNUC_MINOR__ >= 404) && (__GNUC__ < 7)
 #  pragma GCC optimize("-ffunction-sections")
 #endif
 


### PR DESCRIPTION
GCC 7 and later report lots of bad option warnings due to the fact, that the `-ffunction-sections` option can no longer be set on a per function basis. The option may be specified as command-line argument only.

This change in GCC's behavior was made, because  `-ffunction-sections` and ` -fdata-sections` can't be unset once set. See this [GCC bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81368) for details.

As GCC's behavior in earlier versions was also broken, the `#pragma` should probably be removed altogether. This PR fixes the warnings, so that you can build with `-Werror`.