### PR TITLE
Remove the #pragma for -ffunctions-sections

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -170,11 +170,6 @@
 #  define unreachable() do {} while (0)
 #endif
 
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && \
-    (__GNUC__ * 100 + __GNUC_MINOR__ >= 404)
-#  pragma GCC optimize("-ffunction-sections")
-#endif
-
 static inline bool add_check_overflow(size_t v1, size_t v2, size_t *r)
 {
 #if ((defined(__GNUC__) && (__GNUC__ >= 5)) && !defined(__INTEL_COMPILER)) || __has_builtin(__builtin_add_overflow)


### PR DESCRIPTION
Recent GCC have begun complaining about it. The buildsystem should do
this, not a header.

 compilersupport_p.h:175:11: warning: bad option '-ffunction-sections' to pragma 'optimize' [-Wpragmas]

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>