### PR TITLE
Removed `_POSIX_C_SOURCE` defines where `_GNU_SOURCE` was also defined, as `_GNU_SOURCE` implicitly defines `_POSIX_C_SOURCE`

### DIFF
--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -25,7 +25,6 @@
 #define _BSD_SOURCE 1
 #define _DEFAULT_SOURCE 1
 #define _GNU_SOURCE 1
-#define _POSIX_C_SOURCE 200809L
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif

--- a/tools/json2cbor/json2cbor.c
+++ b/tools/json2cbor/json2cbor.c
@@ -22,7 +22,6 @@
 **
 ****************************************************************************/
 
-#define _POSIX_C_SOURCE 200809L
 #define _GNU_SOURCE
 #include "cbor.h"
 #include "cborinternal_p.h"


### PR DESCRIPTION
Fixes https://github.com/intel/tinycbor/issues/220.

As explained in https://github.com/intel/tinycbor/issues/220, on macOS/BSD, `#define _POSIX_C_SOURCE` supersedes `#define _GNU_SOURCE` and prevents the GNU extension `asprintf` from being defined, which causes a compile error in `json2cbor.c`.  To fix this, we can simply remove the `#define _POSIX_C_SOURCE 200809L`, as `#define _GNU_SOURCE` implies it, but without the superseding behavior seen on macOS/BSD.

Specifically, according to https://man7.org/linux/man-pages/man7/feature_test_macros.7.html,

> `_GNU_SOURCE`
> Defining this macro (with any value) implicitly defines `_ATFILE_SOURCE`, `_LARGEFILE64_SOURCE`, `_ISOC99_SOURCE`, `_XOPEN_SOURCE_EXTENDED`, `_POSIX_SOURCE`, `_POSIX_C_SOURCE` with the value 200809L (200112L in glibc versions before 2.10; 199506L in glibc versions before 2.5; 199309L in glibc versions before 2.1) and `_XOPEN_SOURCE` with the value 700 (600 in glibc versions before 2.10; 500 in glibc versions before 2.2).  In addition, various GNU-specific extensions are also exposed.
> 
> Since glibc 2.19, defining `_GNU_SOURCE` also has the effect of implicitly defining `_DEFAULT_SOURCE`.  In glibc versions before 2.20, defining `_GNU_SOURCE` also had the effect of implicitly defining `_BSD_SOURCE` and `_SVID_SOURCE`.