### PR TITLE
tst_Encoder: port away from Q_FOREACH

### DIFF
--- a/tests/encoder/encoder.pro
+++ b/tests/encoder/encoder.pro
@@ -3,6 +3,8 @@ SOURCES += tst_encoder.cpp
 CONFIG += testcase parallel_test c++11
 QT = core testlib
 
+DEFINES += QT_NO_FOREACH QT_NO_AS_CONST
+
 INCLUDEPATH += ../../src
 msvc: POST_TARGETDEPS = ../../lib/tinycbor.lib
 else: POST_TARGETDEPS += ../../lib/libtinycbor.a

--- a/tests/encoder/tst_encoder.cpp
+++ b/tests/encoder/tst_encoder.cpp
@@ -29,6 +29,19 @@
 #include <qfloat16.h>
 #endif
 
+#include <utility>
+namespace t17 {
+#ifdef __cpp_lib_as_const
+    using std::as_const;
+#else
+    template <typename T>
+    constexpr typename std::add_const<T>::type &as_const(T &t) noexcept { return t; }
+    // prevent rvalue arguments:
+    template <typename T>
+    void as_const(const T &&) = delete;
+#endif // __cpp_lib_as_const
+} // namespace t17
+
 Q_DECLARE_METATYPE(CborError)
 namespace QTest {
 template<> char *toString<CborError>(const CborError &err)
@@ -153,7 +166,7 @@ CborError encodeVariant(CborEncoder *encoder, const QVariant &v)
             CborError err = cbor_encoder_create_array(encoder, &sub, len);
             if (err && !isOomError(err))
                 return err;
-            foreach (const QVariant &v2, list) {
+            for (const QVariant &v2 : t17::as_const(list)) {
                 err = static_cast<CborError>(err | encodeVariant(&sub, v2));
                 if (err && !isOomError(err))
                     return err;


### PR DESCRIPTION
Qt is defaulting to QT_NO_FOREACH these days, so make sure we integrate nicely with downstream and fix the single Q_FOREACH/foreach user, in tst_encoder.cpp.

Unfortunately, the container's initialization code doesn't exactly lend itself to making the container const (not even IILE (Immediately-Invoked Lambda Expression) would help here, due to the interdependency with `len`), so the idiomatic solution would be to use std::as_const()/qAsConst().

The former is available from C++17, which we don't require, yet, and the latter is not available under QT_NO_AS_CONST (the default for Qt these days), so grab the nettle and implement a t17::as_const() that switches between a manual implementation of std::as_const and the real thing, depending on __cpp_lib_as_const. The `t17` here mimicks the qNN (q20::remove_cvref_t/q23::forward_like/etc) mechanism used in Qt itself for backports, with s/q/t/ because ... _T_inyCbor.

The t17 implementation is local to tst_encoder.cpp, but can easily be extracted into a separate header once more users emerge.