### PR TITLE
tst_Parser: fix build: define CBOR_PARSER_MAX_RECURSIONS

### DIFF
--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -38,6 +38,10 @@
 #  include <windows.h>
 #endif
 
+#ifndef CBOR_PARSER_MAX_RECURSIONS
+#  define CBOR_PARSER_MAX_RECURSIONS 1024
+#endif
+
 #ifndef QCOMPARE_EQ
 // added for Qt 6.4
 #  define QCOMPARE_EQ QCOMPARE


### PR DESCRIPTION
I don't know how this was compiling.