### PR TITLE
cbor: reduce CborEncoder cacheline size to 24 bytes for x86-64 arch

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -230,8 +230,16 @@ struct CborEncoder
         CborEncoderWriteFunction writer;
     } data;
     uint8_t *end;
+#ifdef __i386__
+    uint32_t remaining;
+    int flags;
+#elifdef __x86_64__
+    uint64_t remaining : 58;
+    int flags : 6;
+#else
     size_t remaining;
     int flags;
+#endif
 };
 typedef struct CborEncoder CborEncoder;
 


### PR DESCRIPTION
@thiagomacieira,
## About patch changes

size_t have 8 byte in x64 arch, flags strict 4 byte (int) therefore, C compiler adding +4 bytes padding in memory layout for struct.

Before this patch CborEncoder have size in diff arch (x86 - 24 bytes, x64 - 32 bytes).

Now size is identical, uint64_t is very difficult to fill, so I shortened range using bit fields. This change may be performance-critical for older processors without L3 cache, low ram capacity or embedded systems.