### PR TITLE
CI: update the macOS images to more modern versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++
             -DCMAKE_CXX_FLAGS_DEBUG="-Werror"
         include:
-        - os: macos-13
+        - os: macos-latest
           build_cfg:
             name: clang-small
             cmakeflags: >-
@@ -72,7 +72,7 @@ jobs:
               -DCMAKE_C_FLAGS="-Oz -g -Werror"
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
-        - os: macos-13
+        - os: macos-15-intel
           build_cfg:
             name: clang
             cmakeflags: >-


### PR DESCRIPTION
macos-13 no longer exists in GitHub Actions.