### PR TITLE
CI: Disable building the tools for macOS small

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
               -DCMAKE_C_FLAGS="-Oz -g -Werror"
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
+              -DWITH_TOOLS=OFF
         - os: macos-15-intel
           build_cfg:
             name: clang


### PR DESCRIPTION
The build fails after the transition to Apple silicon and I don't know why:
```
: && /usr/bin/clang -Oz -g -Werror -arch arm64 -Wl,-search_paths_first -Wl,-headerpad_max_install_names tools/json2cbor/CMakeFiles/json2cbor.dir/json2cbor.c.o -o tools/json2cbor/json2cbor  libtinycbor.a  -lcjson  -lm && :
ld: library 'cjson' not found
```

Homebrew says it installed and CMake says it found it.
```
-- Checking for module 'libcjson'
--   Found libcjson, version 1.7.19
```

I won't investigate.