### PR TITLE
Fix build with pre-C23 compilers other than GCC, Clang, or MSVC

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -225,6 +225,8 @@
 #  define unreachable() __builtin_unreachable()
 #elif defined(_MSC_VER)
 #  define unreachable() __assume(0)
+#else
+#  define unreachable()
 #endif
 
 static inline bool add_check_overflow(size_t v1, size_t v2, size_t *r)


### PR DESCRIPTION
We forgot to define `unreachable()` for them.

Found when trying to compile Qt for INTEGRITY:
```
"/home/qt/work/qt/qtbase/src/corelib/../3rdparty/tinycbor/src/cborparser.c", line 246: error #20:
           identifier "unreachable" is undefined
               cbor_assert(false);  /* these conditions can't be reached */
               ^
```