### PR TITLE
Return error instead of asserting on CborInvalidType in advance functions

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -453,7 +453,8 @@ CborError cbor_value_validate_basic(const CborValue *it)
  */
 CborError cbor_value_advance_fixed(CborValue *it)
 {
-    cbor_assert(it->type != CborInvalidType);
+    if (it->type == CborInvalidType)
+        return CborErrorIllegalType;
     cbor_assert(is_fixed_type(it->type));
     if (!it->remaining)
         return CborErrorAdvancePastEOF;
@@ -505,7 +506,8 @@ static CborError advance_recursive(CborValue *it, int nestingLevel)
  */
 CborError cbor_value_advance(CborValue *it)
 {
-    cbor_assert(it->type != CborInvalidType);
+    if (it->type == CborInvalidType)
+        return CborErrorIllegalType;
     if (!it->remaining)
         return CborErrorAdvancePastEOF;
     return advance_recursive(it, CBOR_PARSER_MAX_RECURSIONS);


### PR DESCRIPTION
## Summary

Replace `cbor_assert(it->type != CborInvalidType)` with an explicit error return
(`CborErrorIllegalType`) in `cbor_value_advance()` and `cbor_value_advance_fixed()`.

### Problem

When parsing malformed CBOR input, recursive container walking can produce a
`CborInvalidType` state in the iterator. The current code triggers `assert()` → `abort()`,
which is inappropriate for a library that processes untrusted input. Callers have no way
to handle the error gracefully.

**Crash output:**
```
fuzz_tinycbor: cborparser.c:508: CborError cbor_value_advance(CborValue *):
  Assertion `it->type != CborInvalidType' failed.
SUMMARY: libFuzzer: deadly signal
```

### Fix

Replace the assertion with an early return of `CborErrorIllegalType`, allowing callers
to detect and handle invalid CBOR data without crashing. The same pattern is applied
to both `cbor_value_advance()` and `cbor_value_advance_fixed()`.

### Testing

Found by fuzzing with libFuzzer + AddressSanitizer on tinycbor bundled with ESP-IDF v5.3.
The fix eliminates the crash on malformed input while preserving correct behavior on valid CBOR data.