### PR TITLE
support picolibc

### DIFF
--- a/src/open_memstream.c
+++ b/src/open_memstream.c
@@ -38,7 +38,7 @@
 #if defined(HAVE_OPEN_FUNOPEN)
 typedef int RetType;
 typedef int LenType;
-#elif defined(HAVE_OPEN_FOPENCOOKIE)
+#elif defined(__PICOLIBC__) || defined(HAVE_OPEN_FOPENCOOKIE)
 typedef ssize_t RetType;
 typedef size_t LenType;
 #else
@@ -54,7 +54,11 @@ struct Buffer
     size_t alloc;
 };
 
+#ifdef __PICOLIBC__
+static RetType write_to_buffer(void *cookie, const void *data, LenType len)
+#else
 static RetType write_to_buffer(void *cookie, const char *data, LenType len)
+#endif
 {
     struct Buffer *b = (struct Buffer *)cookie;
     char *ptr = *b->ptr;
@@ -99,7 +103,7 @@ FILE *open_memstream(char **bufptr, size_t *lenptr)
     *bufptr = NULL;
     *lenptr = 0;
 
-#if defined(HAVE_OPEN_FUNOPEN)
+#if defined(__PICOLIBC__) || defined(HAVE_OPEN_FUNOPEN)
     return funopen(b, NULL, write_to_buffer, NULL, close_buffer);
 #elif defined(HAVE_OPEN_FOPENCOOKIE)
     static const cookie_io_functions_t vtable = {


### PR DESCRIPTION
With current `HAVE_OPEN_FUNOPEN` and `HAVE_OPEN_FOPENCOOKIE` defines i can not configure `src/open_memstream.c` to work with picolibc's version of [`funopen`](https://github.com/picolibc/picolibc/blob/5c5b147244adffdf197c05841f5b4ce1d26f92bb/libc/include/stdio.h#L488).

This PR is just POC (i'm sure there is a cleaner way) how to configure it to work.

picolibc is default libc for espressif's [esp-idf](https://github.com/espressif/esp-idf) from version 6 so it's going to be used there a lot so it would be cool if tinycbor could support picolibc somehow as well.