### PR TITLE
compilersupport: fix build with GCC < 11

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -52,8 +52,12 @@
 #  define cbor_static_assert(x)         ((void)sizeof(char[2*!!(x) - 1]))
 #endif
 
-#if defined(__has_cpp_attribute)    // C23 and C++17
+#if defined(__has_cpp_attribute) && defined(__cplusplus)    // C++17
 #  if __has_cpp_attribute(fallthrough)
+#    define CBOR_FALLTHROUGH            [[fallthrough]]
+#  endif
+#elif defined(__has_c_attribute) && !defined(__cplusplus)   // C23
+#  if __has_c_attribute(fallthrough)
 #    define CBOR_FALLTHROUGH            [[fallthrough]]
 #  endif
 #endif


### PR DESCRIPTION
Commit 45e4641 ("Fix build with GCC < 11: [[fallthrough]] is supported but not allowed in C") introduced a fix for old GCC versions, but commit 91d1c50 ("compilersupport: fix compilation in C23 mode") reverted it, reintroducing the build failure.

Revert the revert.

This builds fine with both an old toolchain and a new one when I force C23 (despite the top-level CMakeFile normally forcing it to C99). I'm not sure if this was an intentional change or just an accident?