### PR TITLE
CMake: fixed `tinycbor.pc` install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tinycbor
 )
 install(FILES
-  ${CMAKE_BINARY_DIR}/tinycbor.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/tinycbor.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 install(


### PR DESCRIPTION
The line `configure_file(tinycbor.pc.in tinycbor.pc @ONLY)` generated the file into `CMAKE_CURRENT_BINARY_DIR`, but the installation of this file was being done using `CMAKE_BINARY_DIR`. This creates an error if tinycbor is added through `add_subdirectory`, because it tries looking that the root binary directory, but doesn't find it there because tinycbor gets its own subdirectory. This should fix the installation by using that specific directory.