### PR TITLE
CI: enable VS2026 in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,13 +4,18 @@ pull_requests:
 image:
 - Visual Studio 2019
 - Visual Studio 2022
+- Visual Studio 2026
 install:
 - cmd: >-
     if /i "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64) & (set QTDIR=C:\Qt\6.5\msvc2019_64)
 
     if /i "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" (call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat") & (set QTDIR=C:\Qt\6.8\msvc2022_64)
 
+    if /i "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2026" (call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat") & (set QTDIR=C:\Qt\6.11\msvc2022_64)
+
     set path=%PATH%;%QTDIR%\bin
+
+    set CMAKE_PREFIX_PATH=%QTDIR%
 build_script:
 - cmd: >-
     cmake -S. -Bbuild -GNinja -DWITH_CBOR2JSON=OFF -DBUILD_TESTING=ON -DCMAKE_C_FLAGS="-W3 -Os -MDd" -DCMAKE_CXX_FLAGS="-W3 -O2 -MDd"


### PR DESCRIPTION
There is no installation for VS2026, but the 2022 will do, as cl.exe has remained binary-compatible since VS2015.